### PR TITLE
Switch to using old anonymous function syntax

### DIFF
--- a/R/aggr_es.R
+++ b/R/aggr_es.R
@@ -91,7 +91,7 @@ aggr_es = function(object,
     )
     ## Bind together and capture/re-assign and the hypothesis attribute (again,
     ## mostly for the "both" case)
-    hyp_attr = sapply(res, \(x) attributes(x)["hypothesis"])
+    hyp_attr = sapply(res, function(x) {attributes(x)["hypothesis"]})
     res = do.call("rbind", res)
     row.names(res) = NULL
     if (period == "both") {


### PR DESCRIPTION
Hi there, 

Thanks for writing such a fantastic package! I'm writing to ask if you would consider changing [this line](https://github.com/grantmcdermott/ggiplot/blob/2eb05e3d13dcddf20ab293a8c027b0ee13b4d1a4/R/aggr_es.R#L94C1-L94C61) to use the older anonymous function syntax `function(x){expression}`.  

The `\(x) expression` syntax is great, but it means that you can't install the package on machines with pre-2021 versions of R installed.  Changing this line would mean that you are able to use the package on many more versions of R at the cost of tiny bit of expressiveness. 

Best, and thanks for your help, 
Ben 