### PR TITLE
Replace ggh4x with legendry

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,11 +30,11 @@ Depends:
     fixest (>= 0.11.2)
 Imports: 
     dreamerr,
-    ggh4x,
     scales,
     marginaleffects (>= 0.10.0),
     stats,
-    utils
+    utils,
+    legendry (>= 0.2)
 Suggests: 
     knitr,
     rmarkdown,

--- a/R/ggiplot.R
+++ b/R/ggiplot.R
@@ -476,11 +476,6 @@ ggiplot = function(
           )
   }
 
-  if (has_groups) {
-  	gg = gg +
-  		theme(ggh4x.axis.nestline = element_line(linewidth = 0.5))
-  }
-
   return(gg)
 
 }

--- a/R/ggiplot.R
+++ b/R/ggiplot.R
@@ -144,11 +144,24 @@ ggiplot = function(
   # Prep data for nested grouping
   has_groups = (!is.null(attributes(data)[["has_groups"]]) && isTRUE(attributes(data)[["has_groups"]]))
   if (isTRUE(has_groups)) {
-  	data[["x"]] = interaction(
-  		data[["x"]], data[["group_var"]],
-  		sep = "___", drop = TRUE#, lex.order = TRUE
-  		)
-  	data[["group_var"]] = NULL
+
+  	key <- unique(data[c("x", "group_var")])
+  	key <- key[order(key[["group_var"]], key[["x"]]), , drop = FALSE]
+  	xlimits <- as.character(key[["x"]])
+
+  	rle <- rle(as.character(key[["group_var"]]))
+  	keep <- nzchar(rle$values)
+  	end <- cumsum(rle$lengths)
+  	start <- end - rle$lengths + 1L
+
+  	key <- legendry::key_range_manual(
+  		start = xlimits[start[keep]],
+  		end   = xlimits[end[keep]],
+  		name  = rle$values[keep],
+  		level = 1L
+  	)
+
+  	data[["group_var"]] <- NULL
   }
 
   yrange = range(c(data[["ci_low"]], data[["ci_high"]]), na.rm = TRUE)
@@ -423,7 +436,13 @@ ggiplot = function(
    } +
    labs(x = xlab, y = ylab, title = main) + {
    	if (has_groups) {
-   		scale_x_discrete(guide = ggh4x::guide_axis_nested(delim = "___"))
+   		scale_x_discrete(
+   			limits = xlimits,
+   			guide = legendry::guide_axis_nested(
+   				key = key,
+   				theme = theme(legendry.bracket = element_line(linewidth = 0.5))
+   			)
+   		)
    	}
    } +
    {

--- a/inst/tinytest/_tinysnapshot/ggcoefplot_did.svg
+++ b/inst/tinytest/_tinysnapshot/ggcoefplot_did.svg
@@ -24,63 +24,63 @@
 <rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMjcuOTB8NDk4LjUyfDIyLjc3fDQ3NC4yMQ=='>
-    <rect x='27.90' y='22.77' width='470.62' height='451.45' />
+  <clipPath id='cpMjcuOTB8NDk4LjUyfDIyLjc3fDQ2OS45Ng=='>
+    <rect x='27.90' y='22.77' width='470.62' height='447.19' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjcuOTB8NDk4LjUyfDIyLjc3fDQ3NC4yMQ==)'>
-<rect x='27.90' y='22.77' width='470.62' height='451.45' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='27.90' y1='326.76' x2='498.52' y2='326.76' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='55.58' y1='298.41' x2='55.58' y2='292.60' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='101.72' y1='442.50' x2='101.72' y2='301.14' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='147.86' y1='436.42' x2='147.86' y2='297.24' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='194.00' y1='406.01' x2='194.00' y2='265.07' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='240.14' y1='453.69' x2='240.14' y2='315.17' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='286.28' y1='367.04' x2='286.28' y2='236.11' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='332.42' y1='281.32' x2='332.42' y2='141.07' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='378.56' y1='283.77' x2='378.56' y2='124.94' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='424.70' y1='244.67' x2='424.70' y2='104.98' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='470.84' y1='185.95' x2='470.84' y2='43.29' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='55.58' cy='295.50' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='101.72' cy='371.82' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='147.86' cy='366.83' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='194.00' cy='335.54' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='240.14' cy='384.43' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='286.28' cy='301.57' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='332.42' cy='211.19' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='378.56' cy='204.36' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='424.70' cy='174.82' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='470.84' cy='114.62' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='27.90' y='22.77' width='470.62' height='451.45' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMjcuOTB8NDk4LjUyfDIyLjc3fDQ2OS45Ng==)'>
+<rect x='27.90' y='22.77' width='470.62' height='447.19' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='27.90' y1='323.90' x2='498.52' y2='323.90' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='55.58' y1='295.81' x2='55.58' y2='290.05' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='101.72' y1='438.55' x2='101.72' y2='298.52' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='147.86' y1='432.52' x2='147.86' y2='294.65' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='194.00' y1='402.40' x2='194.00' y2='262.79' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='240.14' y1='449.63' x2='240.14' y2='312.42' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='286.28' y1='363.80' x2='286.28' y2='234.10' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='332.42' y1='278.88' x2='332.42' y2='139.95' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='378.56' y1='281.32' x2='378.56' y2='123.98' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='424.70' y1='242.58' x2='424.70' y2='104.21' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='470.84' y1='184.41' x2='470.84' y2='43.09' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='55.58' cy='292.93' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='101.72' cy='368.53' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='147.86' cy='363.59' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='194.00' cy='332.59' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='240.14' cy='381.02' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='286.28' cy='298.95' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='332.42' cy='209.42' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='378.56' cy='202.65' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='424.70' cy='173.39' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='470.84' cy='113.75' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='27.90' y='22.77' width='470.62' height='447.19' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<text x='22.96' y='329.79' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='22.96' y='169.23' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>5</text>
-<polyline points='25.16,326.76 27.90,326.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='25.16,166.20 27.90,166.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='55.58,474.21 55.58,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='101.72,474.21 101.72,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='147.86,474.21 147.86,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='194.00,474.21 194.00,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='240.14,474.21 240.14,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='286.28,474.21 286.28,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='332.42,474.21 332.42,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.56,474.21 378.56,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='424.70,474.21 424.70,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='470.84,474.21 470.84,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='55.58' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='9.30px' lengthAdjust='spacingAndGlyphs'>x1</text>
-<text x='101.72' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='147.86' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='194.00' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='240.14' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='286.28' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='332.42' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>7</text>
-<text x='378.56' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>8</text>
-<text x='424.70' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>9</text>
-<text x='470.84' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
-<polyline points='90.18,487.74 482.37,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='286.28' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='75.36px' lengthAdjust='spacingAndGlyphs'>treat × (period = ...)</text>
-<text transform='translate(13.05,248.49) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
+<text x='22.96' y='326.93' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='22.96' y='167.88' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>5</text>
+<polyline points='25.16,323.90 27.90,323.90 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,164.85 27.90,164.85 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='55.58,472.70 55.58,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='101.72,472.70 101.72,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='147.86,472.70 147.86,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='194.00,472.70 194.00,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='240.14,472.70 240.14,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='286.28,472.70 286.28,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='332.42,472.70 332.42,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='378.56,472.70 378.56,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='424.70,472.70 424.70,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='470.84,472.70 470.84,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='55.58' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='9.30px' lengthAdjust='spacingAndGlyphs'>x1</text>
+<text x='101.72' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='147.86' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='194.00' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='240.14' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='286.28' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='332.42' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='378.56' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='424.70' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='470.84' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<polyline points='83.26,485.61 489.29,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='286.28' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='75.36px' lengthAdjust='spacingAndGlyphs'>treat × (period = ...)</text>
+<text transform='translate(13.05,246.36) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
 <text x='27.90' y='14.55' style='font-size: 13.20px; font-family: "Liberation Sans";' textLength='62.09px' lengthAdjust='spacingAndGlyphs'>Effect on y</text>
 </g>
 </svg>

--- a/inst/tinytest/_tinysnapshot/ggcoefplot_did_iid.svg
+++ b/inst/tinytest/_tinysnapshot/ggcoefplot_did_iid.svg
@@ -24,63 +24,63 @@
 <rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMjcuOTB8NDk4LjUyfDIyLjc3fDQ3NC4yMQ=='>
-    <rect x='27.90' y='22.77' width='470.62' height='451.45' />
+  <clipPath id='cpMjcuOTB8NDk4LjUyfDIyLjc3fDQ2OS45Ng=='>
+    <rect x='27.90' y='22.77' width='470.62' height='447.19' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjcuOTB8NDk4LjUyfDIyLjc3fDQ3NC4yMQ==)'>
-<rect x='27.90' y='22.77' width='470.62' height='451.45' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='27.90' y1='325.78' x2='498.52' y2='325.78' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='55.58' y1='297.32' x2='55.58' y2='291.67' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='101.72' y1='441.04' x2='101.72' y2='300.73' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='147.86' y1='436.03' x2='147.86' y2='295.74' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='194.00' y1='404.74' x2='194.00' y2='264.40' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='240.14' y1='453.69' x2='240.14' y2='313.33' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='286.28' y1='370.71' x2='286.28' y2='230.43' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='332.42' y1='280.26' x2='332.42' y2='139.93' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='378.56' y1='273.39' x2='378.56' y2='133.12' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='424.70' y1='243.83' x2='424.70' y2='103.56' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='470.84' y1='183.57' x2='470.84' y2='43.29' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='55.58' cy='294.49' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='101.72' cy='370.89' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='147.86' cy='365.89' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='194.00' cy='334.57' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='240.14' cy='383.51' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='286.28' cy='300.57' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='332.42' cy='210.10' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='378.56' cy='203.26' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='424.70' cy='173.69' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='470.84' cy='113.43' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='27.90' y='22.77' width='470.62' height='451.45' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMjcuOTB8NDk4LjUyfDIyLjc3fDQ2OS45Ng==)'>
+<rect x='27.90' y='22.77' width='470.62' height='447.19' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='27.90' y1='322.93' x2='498.52' y2='322.93' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='55.58' y1='294.73' x2='55.58' y2='289.13' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='101.72' y1='437.10' x2='101.72' y2='298.11' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='147.86' y1='432.14' x2='147.86' y2='293.17' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='194.00' y1='401.14' x2='194.00' y2='262.12' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='240.14' y1='449.63' x2='240.14' y2='310.59' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='286.28' y1='367.43' x2='286.28' y2='228.47' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='332.42' y1='277.84' x2='332.42' y2='138.83' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='378.56' y1='271.03' x2='378.56' y2='132.08' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='424.70' y1='241.75' x2='424.70' y2='102.80' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='470.84' y1='182.05' x2='470.84' y2='43.09' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='55.58' cy='291.93' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='101.72' cy='367.61' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='147.86' cy='362.65' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='194.00' cy='331.63' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='240.14' cy='380.11' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='286.28' cy='297.95' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='332.42' cy='208.33' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='378.56' cy='201.56' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='424.70' cy='172.27' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='470.84' cy='112.57' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='27.90' y='22.77' width='470.62' height='447.19' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<text x='22.96' y='328.81' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='22.96' y='168.09' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>5</text>
-<polyline points='25.16,325.78 27.90,325.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='25.16,165.06 27.90,165.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='55.58,474.21 55.58,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='101.72,474.21 101.72,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='147.86,474.21 147.86,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='194.00,474.21 194.00,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='240.14,474.21 240.14,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='286.28,474.21 286.28,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='332.42,474.21 332.42,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='378.56,474.21 378.56,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='424.70,474.21 424.70,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='470.84,474.21 470.84,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='55.58' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='9.30px' lengthAdjust='spacingAndGlyphs'>x1</text>
-<text x='101.72' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='147.86' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='194.00' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='240.14' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='286.28' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='332.42' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>7</text>
-<text x='378.56' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>8</text>
-<text x='424.70' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>9</text>
-<text x='470.84' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
-<polyline points='90.18,487.74 482.37,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='286.28' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='75.36px' lengthAdjust='spacingAndGlyphs'>treat × (period = ...)</text>
-<text transform='translate(13.05,248.49) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
+<text x='22.96' y='325.96' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='22.96' y='166.75' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>5</text>
+<polyline points='25.16,322.93 27.90,322.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,163.72 27.90,163.72 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='55.58,472.70 55.58,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='101.72,472.70 101.72,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='147.86,472.70 147.86,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='194.00,472.70 194.00,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='240.14,472.70 240.14,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='286.28,472.70 286.28,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='332.42,472.70 332.42,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='378.56,472.70 378.56,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='424.70,472.70 424.70,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='470.84,472.70 470.84,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='55.58' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='9.30px' lengthAdjust='spacingAndGlyphs'>x1</text>
+<text x='101.72' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='147.86' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='194.00' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='240.14' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='286.28' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='332.42' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='378.56' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='424.70' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='470.84' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<polyline points='83.26,485.61 489.29,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='286.28' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='75.36px' lengthAdjust='spacingAndGlyphs'>treat × (period = ...)</text>
+<text transform='translate(13.05,246.36) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
 <text x='27.90' y='14.55' style='font-size: 13.20px; font-family: "Liberation Sans";' textLength='62.09px' lengthAdjust='spacingAndGlyphs'>Effect on y</text>
 </g>
 </svg>

--- a/inst/tinytest/_tinysnapshot/ggcoefplot_group_names_prefix.svg
+++ b/inst/tinytest/_tinysnapshot/ggcoefplot_group_names_prefix.svg
@@ -24,53 +24,53 @@
 <rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMzAuODN8NDk4LjUyfDIyLjc3fDQ3NC4yMQ=='>
-    <rect x='30.83' y='22.77' width='467.69' height='451.45' />
+  <clipPath id='cpMzAuODN8NDk4LjUyfDIyLjc3fDQ2OS45Ng=='>
+    <rect x='30.83' y='22.77' width='467.69' height='447.19' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzAuODN8NDk4LjUyfDIyLjc3fDQ3NC4yMQ==)'>
-<rect x='30.83' y='22.77' width='467.69' height='451.45' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='30.83' y1='289.19' x2='498.52' y2='289.19' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='76.09' y1='453.69' x2='76.09' y2='346.97' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='151.52' y1='252.96' x2='151.52' y2='204.93' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='226.96' y1='238.30' x2='226.96' y2='218.43' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='302.39' y1='323.14' x2='302.39' y2='291.36' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='377.83' y1='177.09' x2='377.83' y2='108.50' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='453.26' y1='140.10' x2='453.26' y2='43.29' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='76.09' cy='400.33' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='151.52' cy='228.94' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='226.96' cy='228.36' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='302.39' cy='307.25' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='377.83' cy='142.80' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='453.26' cy='91.69' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='30.83' y='22.77' width='467.69' height='451.45' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMzAuODN8NDk4LjUyfDIyLjc3fDQ2OS45Ng==)'>
+<rect x='30.83' y='22.77' width='467.69' height='447.19' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='30.83' y1='286.68' x2='498.52' y2='286.68' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='76.09' y1='449.63' x2='76.09' y2='343.91' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='151.52' y1='250.79' x2='151.52' y2='203.21' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='226.96' y1='236.27' x2='226.96' y2='216.59' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='302.39' y1='320.31' x2='302.39' y2='288.83' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='377.83' y1='175.64' x2='377.83' y2='107.69' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='453.26' y1='138.99' x2='453.26' y2='43.09' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='76.09' cy='396.77' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='151.52' cy='227.00' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='226.96' cy='226.43' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='302.39' cy='304.57' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='377.83' cy='141.67' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='453.26' cy='91.04' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='30.83' y='22.77' width='467.69' height='447.19' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<text x='25.90' y='392.25' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-1</text>
-<text x='25.90' y='292.22' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='25.90' y='192.18' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='25.90' y='92.14' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>2</text>
-<polyline points='28.09,389.23 30.83,389.23 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='28.09,289.19 30.83,289.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='28.09,189.15 30.83,189.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='28.09,89.11 30.83,89.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='76.09,474.21 76.09,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='151.52,474.21 151.52,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='226.96,474.21 226.96,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='302.39,474.21 302.39,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='377.83,474.21 377.83,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='453.26,474.21 453.26,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='76.09' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
-<text x='151.52' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='45.00px' lengthAdjust='spacingAndGlyphs'>Petal.Width</text>
-<text x='226.96' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='26.93px' lengthAdjust='spacingAndGlyphs'>Length</text>
-<text x='302.39' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='22.49px' lengthAdjust='spacingAndGlyphs'>Width</text>
-<text x='377.83' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='37.65px' lengthAdjust='spacingAndGlyphs'>versicolor</text>
-<text x='453.26' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='32.27px' lengthAdjust='spacingAndGlyphs'>virginica</text>
-<polyline points='208.10,487.74 321.25,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='358.97,487.74 472.12,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='264.67' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='22.51px' lengthAdjust='spacingAndGlyphs'>Sepal</text>
-<text x='415.54' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='31.31px' lengthAdjust='spacingAndGlyphs'>Species</text>
-<text transform='translate(13.05,248.49) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
+<text x='25.90' y='388.80' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='25.90' y='289.71' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='25.90' y='190.61' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='25.90' y='91.52' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polyline points='28.09,385.77 30.83,385.77 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,286.68 30.83,286.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,187.58 30.83,187.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,88.49 30.83,88.49 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='76.09,472.70 76.09,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='151.52,472.70 151.52,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='226.96,472.70 226.96,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='302.39,472.70 302.39,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='377.83,472.70 377.83,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='453.26,472.70 453.26,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='76.09' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
+<text x='151.52' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='45.00px' lengthAdjust='spacingAndGlyphs'>Petal.Width</text>
+<text x='226.96' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='26.93px' lengthAdjust='spacingAndGlyphs'>Length</text>
+<text x='302.39' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='22.49px' lengthAdjust='spacingAndGlyphs'>Width</text>
+<text x='377.83' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='37.65px' lengthAdjust='spacingAndGlyphs'>versicolor</text>
+<text x='453.26' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='32.27px' lengthAdjust='spacingAndGlyphs'>virginica</text>
+<polyline points='196.78,485.61 332.56,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='347.65,485.61 483.43,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='264.67' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='22.51px' lengthAdjust='spacingAndGlyphs'>Sepal</text>
+<text x='415.54' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='31.31px' lengthAdjust='spacingAndGlyphs'>Species</text>
+<text transform='translate(13.05,246.36) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
 <text x='30.83' y='14.55' style='font-size: 13.20px; font-family: "Liberation Sans";' textLength='129.57px' lengthAdjust='spacingAndGlyphs'>Effect on Petal.Length</text>
 </g>
 </svg>

--- a/inst/tinytest/_tinysnapshot/ggcoefplot_group_nonames.svg
+++ b/inst/tinytest/_tinysnapshot/ggcoefplot_group_nonames.svg
@@ -24,53 +24,53 @@
 <rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMzAuODN8NDk4LjUyfDIyLjc3fDQ3NC4yMQ=='>
-    <rect x='30.83' y='22.77' width='467.69' height='451.45' />
+  <clipPath id='cpMzAuODN8NDk4LjUyfDIyLjc3fDQ2OS45Ng=='>
+    <rect x='30.83' y='22.77' width='467.69' height='447.19' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzAuODN8NDk4LjUyfDIyLjc3fDQ3NC4yMQ==)'>
-<rect x='30.83' y='22.77' width='467.69' height='451.45' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='30.83' y1='289.19' x2='498.52' y2='289.19' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='76.09' y1='453.69' x2='76.09' y2='346.97' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='151.52' y1='252.96' x2='151.52' y2='204.93' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='226.96' y1='238.30' x2='226.96' y2='218.43' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='302.39' y1='323.14' x2='302.39' y2='291.36' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='377.83' y1='177.09' x2='377.83' y2='108.50' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='453.26' y1='140.10' x2='453.26' y2='43.29' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='76.09' cy='400.33' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='151.52' cy='228.94' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='226.96' cy='228.36' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='302.39' cy='307.25' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='377.83' cy='142.80' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='453.26' cy='91.69' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='30.83' y='22.77' width='467.69' height='451.45' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMzAuODN8NDk4LjUyfDIyLjc3fDQ2OS45Ng==)'>
+<rect x='30.83' y='22.77' width='467.69' height='447.19' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='30.83' y1='286.68' x2='498.52' y2='286.68' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='76.09' y1='449.63' x2='76.09' y2='343.91' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='151.52' y1='250.79' x2='151.52' y2='203.21' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='226.96' y1='236.27' x2='226.96' y2='216.59' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='302.39' y1='320.31' x2='302.39' y2='288.83' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='377.83' y1='175.64' x2='377.83' y2='107.69' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='453.26' y1='138.99' x2='453.26' y2='43.09' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='76.09' cy='396.77' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='151.52' cy='227.00' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='226.96' cy='226.43' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='302.39' cy='304.57' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='377.83' cy='141.67' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='453.26' cy='91.04' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='30.83' y='22.77' width='467.69' height='447.19' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<text x='25.90' y='392.25' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-1</text>
-<text x='25.90' y='292.22' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='25.90' y='192.18' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='25.90' y='92.14' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>2</text>
-<polyline points='28.09,389.23 30.83,389.23 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='28.09,289.19 30.83,289.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='28.09,189.15 30.83,189.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='28.09,89.11 30.83,89.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='76.09,474.21 76.09,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='151.52,474.21 151.52,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='226.96,474.21 226.96,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='302.39,474.21 302.39,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='377.83,474.21 377.83,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='453.26,474.21 453.26,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='76.09' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
-<text x='151.52' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='45.00px' lengthAdjust='spacingAndGlyphs'>Petal.Width</text>
-<text x='226.96' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='51.88px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
-<text x='302.39' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='47.45px' lengthAdjust='spacingAndGlyphs'>Sepal.Width</text>
-<text x='377.83' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='68.95px' lengthAdjust='spacingAndGlyphs'>Speciesversicolor</text>
-<text x='453.26' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='63.58px' lengthAdjust='spacingAndGlyphs'>Speciesvirginica</text>
-<polyline points='208.10,487.74 321.25,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='358.97,487.74 472.12,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='264.67' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='2.45px' lengthAdjust='spacingAndGlyphs'> </text>
-<text x='415.54' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>  </text>
-<text transform='translate(13.05,248.49) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
+<text x='25.90' y='388.80' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='25.90' y='289.71' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='25.90' y='190.61' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='25.90' y='91.52' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polyline points='28.09,385.77 30.83,385.77 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,286.68 30.83,286.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,187.58 30.83,187.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,88.49 30.83,88.49 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='76.09,472.70 76.09,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='151.52,472.70 151.52,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='226.96,472.70 226.96,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='302.39,472.70 302.39,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='377.83,472.70 377.83,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='453.26,472.70 453.26,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='76.09' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
+<text x='151.52' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='45.00px' lengthAdjust='spacingAndGlyphs'>Petal.Width</text>
+<text x='226.96' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='51.88px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
+<text x='302.39' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='47.45px' lengthAdjust='spacingAndGlyphs'>Sepal.Width</text>
+<text x='377.83' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='68.95px' lengthAdjust='spacingAndGlyphs'>Speciesversicolor</text>
+<text x='453.26' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='63.58px' lengthAdjust='spacingAndGlyphs'>Speciesvirginica</text>
+<polyline points='196.78,485.61 332.56,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='347.65,485.61 483.43,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='264.67' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='2.45px' lengthAdjust='spacingAndGlyphs'> </text>
+<text x='415.54' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>  </text>
+<text transform='translate(13.05,246.36) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
 <text x='30.83' y='14.55' style='font-size: 13.20px; font-family: "Liberation Sans";' textLength='129.57px' lengthAdjust='spacingAndGlyphs'>Effect on Petal.Length</text>
 </g>
 </svg>

--- a/inst/tinytest/_tinysnapshot/ggcoefplot_group_none.svg
+++ b/inst/tinytest/_tinysnapshot/ggcoefplot_group_none.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8NDk4LjUyfDIyLjc3fDQ4NS43MQ=='>

--- a/inst/tinytest/_tinysnapshot/ggcoefplot_groupnames.svg
+++ b/inst/tinytest/_tinysnapshot/ggcoefplot_groupnames.svg
@@ -24,53 +24,53 @@
 <rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMzAuODN8NDk4LjUyfDIyLjc3fDQ3NC4yMQ=='>
-    <rect x='30.83' y='22.77' width='467.69' height='451.45' />
+  <clipPath id='cpMzAuODN8NDk4LjUyfDIyLjc3fDQ2OS45Ng=='>
+    <rect x='30.83' y='22.77' width='467.69' height='447.19' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzAuODN8NDk4LjUyfDIyLjc3fDQ3NC4yMQ==)'>
-<rect x='30.83' y='22.77' width='467.69' height='451.45' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='30.83' y1='289.19' x2='498.52' y2='289.19' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='76.09' y1='453.69' x2='76.09' y2='346.97' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='151.52' y1='252.96' x2='151.52' y2='204.93' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='226.96' y1='238.30' x2='226.96' y2='218.43' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='302.39' y1='323.14' x2='302.39' y2='291.36' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='377.83' y1='177.09' x2='377.83' y2='108.50' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='453.26' y1='140.10' x2='453.26' y2='43.29' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='76.09' cy='400.33' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='151.52' cy='228.94' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='226.96' cy='228.36' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='302.39' cy='307.25' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='377.83' cy='142.80' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='453.26' cy='91.69' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='30.83' y='22.77' width='467.69' height='451.45' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMzAuODN8NDk4LjUyfDIyLjc3fDQ2OS45Ng==)'>
+<rect x='30.83' y='22.77' width='467.69' height='447.19' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='30.83' y1='286.68' x2='498.52' y2='286.68' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='76.09' y1='449.63' x2='76.09' y2='343.91' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='151.52' y1='250.79' x2='151.52' y2='203.21' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='226.96' y1='236.27' x2='226.96' y2='216.59' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='302.39' y1='320.31' x2='302.39' y2='288.83' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='377.83' y1='175.64' x2='377.83' y2='107.69' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='453.26' y1='138.99' x2='453.26' y2='43.09' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='76.09' cy='396.77' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='151.52' cy='227.00' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='226.96' cy='226.43' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='302.39' cy='304.57' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='377.83' cy='141.67' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='453.26' cy='91.04' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='30.83' y='22.77' width='467.69' height='447.19' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<text x='25.90' y='392.25' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-1</text>
-<text x='25.90' y='292.22' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='25.90' y='192.18' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='25.90' y='92.14' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>2</text>
-<polyline points='28.09,389.23 30.83,389.23 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='28.09,289.19 30.83,289.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='28.09,189.15 30.83,189.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='28.09,89.11 30.83,89.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='76.09,474.21 76.09,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='151.52,474.21 151.52,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='226.96,474.21 226.96,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='302.39,474.21 302.39,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='377.83,474.21 377.83,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='453.26,474.21 453.26,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='76.09' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
-<text x='151.52' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='45.00px' lengthAdjust='spacingAndGlyphs'>Petal.Width</text>
-<text x='226.96' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='51.88px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
-<text x='302.39' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='47.45px' lengthAdjust='spacingAndGlyphs'>Sepal.Width</text>
-<text x='377.83' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='68.95px' lengthAdjust='spacingAndGlyphs'>Speciesversicolor</text>
-<text x='453.26' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='63.58px' lengthAdjust='spacingAndGlyphs'>Speciesvirginica</text>
-<polyline points='208.10,487.74 321.25,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='358.97,487.74 472.12,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='264.67' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='22.51px' lengthAdjust='spacingAndGlyphs'>Sepal</text>
-<text x='415.54' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='31.31px' lengthAdjust='spacingAndGlyphs'>Species</text>
-<text transform='translate(13.05,248.49) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
+<text x='25.90' y='388.80' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='7.83px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='25.90' y='289.71' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='25.90' y='190.61' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='25.90' y='91.52' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polyline points='28.09,385.77 30.83,385.77 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,286.68 30.83,286.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,187.58 30.83,187.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,88.49 30.83,88.49 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='76.09,472.70 76.09,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='151.52,472.70 151.52,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='226.96,472.70 226.96,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='302.39,472.70 302.39,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='377.83,472.70 377.83,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='453.26,472.70 453.26,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='76.09' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
+<text x='151.52' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='45.00px' lengthAdjust='spacingAndGlyphs'>Petal.Width</text>
+<text x='226.96' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='51.88px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
+<text x='302.39' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='47.45px' lengthAdjust='spacingAndGlyphs'>Sepal.Width</text>
+<text x='377.83' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='68.95px' lengthAdjust='spacingAndGlyphs'>Speciesversicolor</text>
+<text x='453.26' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='63.58px' lengthAdjust='spacingAndGlyphs'>Speciesvirginica</text>
+<polyline points='196.78,485.61 332.56,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='347.65,485.61 483.43,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='264.67' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='22.51px' lengthAdjust='spacingAndGlyphs'>Sepal</text>
+<text x='415.54' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='31.31px' lengthAdjust='spacingAndGlyphs'>Species</text>
+<text transform='translate(13.05,246.36) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
 <text x='30.83' y='14.55' style='font-size: 13.20px; font-family: "Liberation Sans";' textLength='129.57px' lengthAdjust='spacingAndGlyphs'>Effect on Petal.Length</text>
 </g>
 </svg>

--- a/inst/tinytest/_tinysnapshot/ggcoefplot_interactions.svg
+++ b/inst/tinytest/_tinysnapshot/ggcoefplot_interactions.svg
@@ -24,49 +24,49 @@
 <rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpNDAuMTR8NDk4LjUyfDIyLjc3fDQ3NC4yMQ=='>
-    <rect x='40.14' y='22.77' width='458.38' height='451.45' />
+  <clipPath id='cpNDAuMTR8NDk4LjUyfDIyLjc3fDQ2OS45Ng=='>
+    <rect x='40.14' y='22.77' width='458.38' height='447.19' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDAuMTR8NDk4LjUyfDIyLjc3fDQ3NC4yMQ==)'>
-<rect x='40.14' y='22.77' width='458.38' height='451.45' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='40.14' y1='425.15' x2='498.52' y2='425.15' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='93.03' y1='395.51' x2='93.03' y2='43.29' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='181.18' y1='330.35' x2='181.18' y2='109.31' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='269.33' y1='356.53' x2='269.33' y2='245.11' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='357.48' y1='431.92' x2='357.48' y2='357.08' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='445.63' y1='453.69' x2='445.63' y2='410.22' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='93.03' cy='219.40' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='181.18' cy='219.83' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='269.33' cy='300.82' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='357.48' cy='394.50' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='445.63' cy='431.95' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='40.14' y='22.77' width='458.38' height='451.45' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpNDAuMTR8NDk4LjUyfDIyLjc3fDQ2OS45Ng==)'>
+<rect x='40.14' y='22.77' width='458.38' height='447.19' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='40.14' y1='421.36' x2='498.52' y2='421.36' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='93.03' y1='392.00' x2='93.03' y2='43.09' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='181.18' y1='327.45' x2='181.18' y2='108.49' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='269.33' y1='353.38' x2='269.33' y2='243.02' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='357.48' y1='428.06' x2='357.48' y2='353.93' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='445.63' y1='449.63' x2='445.63' y2='406.57' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='93.03' cy='217.55' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='181.18' cy='217.97' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='269.33' cy='298.20' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='357.48' cy='391.00' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='445.63' cy='428.10' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='40.14' y='22.77' width='458.38' height='447.19' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<text x='35.20' y='428.17' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.00</text>
-<text x='35.20' y='317.61' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.05</text>
-<text x='35.20' y='207.04' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.10</text>
-<text x='35.20' y='96.47' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.15</text>
-<polyline points='37.40,425.15 40.14,425.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='37.40,314.58 40.14,314.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='37.40,204.01 40.14,204.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='37.40,93.45 40.14,93.45 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='93.03,474.21 93.03,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='181.18,474.21 181.18,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='269.33,474.21 269.33,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='357.48,474.21 357.48,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='445.63,474.21 445.63,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='93.03' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='181.18' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='269.33' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>4:wt</text>
-<text x='357.48' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>6:wt</text>
-<text x='445.63' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>8:wt</text>
-<polyline points='70.99,487.74 203.22,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='247.29,487.74 467.67,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='137.10' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='55.30px' lengthAdjust='spacingAndGlyphs'>hp × (am = ...)</text>
-<text x='357.48' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='60.17px' lengthAdjust='spacingAndGlyphs'>disp × (cyl = ...)</text>
-<text transform='translate(13.05,248.49) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
+<text x='35.20' y='424.38' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='35.20' y='314.86' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.05</text>
+<text x='35.20' y='205.33' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.10</text>
+<text x='35.20' y='95.81' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.15</text>
+<polyline points='37.40,421.36 40.14,421.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.40,311.83 40.14,311.83 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.40,202.31 40.14,202.31 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.40,92.78 40.14,92.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='93.03,472.70 93.03,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='181.18,472.70 181.18,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='269.33,472.70 269.33,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='357.48,472.70 357.48,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='445.63,472.70 445.63,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='93.03' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='181.18' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='269.33' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>4:wt</text>
+<text x='357.48' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>6:wt</text>
+<text x='445.63' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>8:wt</text>
+<polyline points='57.77,485.61 216.44,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='234.07,485.61 480.89,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='137.10' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='55.30px' lengthAdjust='spacingAndGlyphs'>hp × (am = ...)</text>
+<text x='357.48' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='60.17px' lengthAdjust='spacingAndGlyphs'>disp × (cyl = ...)</text>
+<text transform='translate(13.05,246.36) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
 <text x='40.14' y='14.55' style='font-size: 13.20px; font-family: "Liberation Sans";' textLength='81.15px' lengthAdjust='spacingAndGlyphs'>Effect on mpg</text>
 </g>
 </svg>

--- a/inst/tinytest/_tinysnapshot/ggcoefplot_interactions_multici.svg
+++ b/inst/tinytest/_tinysnapshot/ggcoefplot_interactions_multici.svg
@@ -24,69 +24,69 @@
 <rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpNDAuMTR8NDk4LjUyfDIyLjc3fDQ3NC4yMQ=='>
-    <rect x='40.14' y='22.77' width='458.38' height='451.45' />
+  <clipPath id='cpNDAuMTR8NDk4LjUyfDIyLjc3fDQ2OS45Ng=='>
+    <rect x='40.14' y='22.77' width='458.38' height='447.19' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDAuMTR8NDk4LjUyfDIyLjc3fDQ3NC4yMQ==)'>
-<rect x='40.14' y='22.77' width='458.38' height='451.45' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='40.14' y1='425.15' x2='498.52' y2='425.15' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='93.03' y1='395.51' x2='93.03' y2='43.29' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='181.18' y1='330.35' x2='181.18' y2='109.31' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='269.33' y1='356.53' x2='269.33' y2='245.11' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='357.48' y1='431.92' x2='357.48' y2='357.08' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='445.63' y1='453.69' x2='445.63' y2='410.22' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='84.21,106.64 101.84,106.64 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='93.03,106.64 93.03,332.15 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='84.21,332.15 101.84,332.15 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='172.36,149.07 189.99,149.07 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='181.18,149.07 181.18,290.59 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='172.36,290.59 189.99,290.59 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='260.51,265.15 278.14,265.15 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='269.33,265.15 269.33,336.49 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='260.51,336.49 278.14,336.49 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='348.66,370.54 366.29,370.54 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='357.48,370.54 357.48,418.46 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='348.66,418.46 366.29,418.46 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='436.81,418.04 454.45,418.04 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='445.63,418.04 445.63,445.87 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='436.81,445.87 454.45,445.87 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='93.03' cy='219.40' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='181.18' cy='219.83' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='269.33' cy='300.82' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='357.48' cy='394.50' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='445.63' cy='431.95' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='93.03' cy='219.40' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='181.18' cy='219.83' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='269.33' cy='300.82' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='357.48' cy='394.50' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='445.63' cy='431.95' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='40.14' y='22.77' width='458.38' height='451.45' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpNDAuMTR8NDk4LjUyfDIyLjc3fDQ2OS45Ng==)'>
+<rect x='40.14' y='22.77' width='458.38' height='447.19' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='40.14' y1='421.36' x2='498.52' y2='421.36' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='93.03' y1='392.00' x2='93.03' y2='43.09' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='181.18' y1='327.45' x2='181.18' y2='108.49' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='269.33' y1='353.38' x2='269.33' y2='243.02' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='357.48' y1='428.06' x2='357.48' y2='353.93' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='445.63' y1='449.63' x2='445.63' y2='406.57' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='84.21,105.85 101.84,105.85 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='93.03,105.85 93.03,329.24 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='84.21,329.24 101.84,329.24 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='172.36,147.88 189.99,147.88 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='181.18,147.88 181.18,288.07 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='172.36,288.07 189.99,288.07 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='260.51,262.87 278.14,262.87 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='269.33,262.87 269.33,333.53 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='260.51,333.53 278.14,333.53 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='348.66,367.27 366.29,367.27 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='357.48,367.27 357.48,414.73 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='348.66,414.73 366.29,414.73 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='436.81,414.31 454.45,414.31 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='445.63,414.31 445.63,441.89 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='436.81,441.89 454.45,441.89 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='93.03' cy='217.55' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='181.18' cy='217.97' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='269.33' cy='298.20' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='357.48' cy='391.00' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='445.63' cy='428.10' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='93.03' cy='217.55' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='181.18' cy='217.97' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='269.33' cy='298.20' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='357.48' cy='391.00' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='445.63' cy='428.10' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='40.14' y='22.77' width='458.38' height='447.19' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<text x='35.20' y='428.17' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.00</text>
-<text x='35.20' y='317.61' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.05</text>
-<text x='35.20' y='207.04' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.10</text>
-<text x='35.20' y='96.47' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.15</text>
-<polyline points='37.40,425.15 40.14,425.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='37.40,314.58 40.14,314.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='37.40,204.01 40.14,204.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='37.40,93.45 40.14,93.45 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='93.03,474.21 93.03,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='181.18,474.21 181.18,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='269.33,474.21 269.33,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='357.48,474.21 357.48,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='445.63,474.21 445.63,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='93.03' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='181.18' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='269.33' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>4:wt</text>
-<text x='357.48' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>6:wt</text>
-<text x='445.63' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>8:wt</text>
-<polyline points='70.99,487.74 203.22,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='247.29,487.74 467.67,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='137.10' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='55.30px' lengthAdjust='spacingAndGlyphs'>hp × (am = ...)</text>
-<text x='357.48' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='60.17px' lengthAdjust='spacingAndGlyphs'>disp × (cyl = ...)</text>
-<text transform='translate(13.05,248.49) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='178.63px' lengthAdjust='spacingAndGlyphs'>Estimate and [80% &amp; 95%] Conf. Int.</text>
+<text x='35.20' y='424.38' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='35.20' y='314.86' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.05</text>
+<text x='35.20' y='205.33' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.10</text>
+<text x='35.20' y='95.81' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='17.14px' lengthAdjust='spacingAndGlyphs'>0.15</text>
+<polyline points='37.40,421.36 40.14,421.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.40,311.83 40.14,311.83 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.40,202.31 40.14,202.31 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.40,92.78 40.14,92.78 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='93.03,472.70 93.03,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='181.18,472.70 181.18,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='269.33,472.70 269.33,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='357.48,472.70 357.48,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='445.63,472.70 445.63,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='93.03' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='181.18' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='269.33' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>4:wt</text>
+<text x='357.48' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>6:wt</text>
+<text x='445.63' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>8:wt</text>
+<polyline points='57.77,485.61 216.44,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='234.07,485.61 480.89,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='137.10' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='55.30px' lengthAdjust='spacingAndGlyphs'>hp × (am = ...)</text>
+<text x='357.48' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='60.17px' lengthAdjust='spacingAndGlyphs'>disp × (cyl = ...)</text>
+<text transform='translate(13.05,246.36) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='178.63px' lengthAdjust='spacingAndGlyphs'>Estimate and [80% &amp; 95%] Conf. Int.</text>
 <text x='40.14' y='14.55' style='font-size: 13.20px; font-family: "Liberation Sans";' textLength='81.15px' lengthAdjust='spacingAndGlyphs'>Effect on mpg</text>
 </g>
 </svg>

--- a/inst/tinytest/_tinysnapshot/ggcoefplot_multi.svg
+++ b/inst/tinytest/_tinysnapshot/ggcoefplot_multi.svg
@@ -21,62 +21,62 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.000000000000064' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMzcuNjl8NDMxLjU0fDIyLjc3fDQ3NC4yMQ=='>
-    <rect x='37.69' y='22.77' width='393.85' height='451.45' />
+  <clipPath id='cpMzcuNjl8NDMxLjU0fDIyLjc3fDQ2OS45Ng=='>
+    <rect x='37.69' y='22.77' width='393.85' height='447.19' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzcuNjl8NDMxLjU0fDIyLjc3fDQ3NC4yMQ==)'>
-<rect x='37.69' y='22.77' width='393.85' height='451.45' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='37.69' y1='369.41' x2='431.54' y2='369.41' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='84.58' y1='327.66' x2='84.58' y2='310.85' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
-<line x1='103.33' y1='286.55' x2='103.33' y2='43.29' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
-<line x1='178.35' y1='377.23' x2='178.35' y2='369.91' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
-<line x1='197.10' y1='453.69' x2='197.10' y2='347.68' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
-<line x1='272.12' y1='378.56' x2='272.12' y2='372.81' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
-<line x1='290.88' y1='416.23' x2='290.88' y2='333.06' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
-<line x1='365.90' y1='378.12' x2='365.90' y2='373.89' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
-<line x1='384.65' y1='371.16' x2='384.65' y2='309.92' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
-<circle cx='84.58' cy='319.25' r='3.02' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
-<polygon points='103.33,160.22 107.40,167.27 99.26,167.27 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
-<circle cx='178.35' cy='373.57' r='3.02' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
-<polygon points='197.10,395.99 201.17,403.03 193.03,403.03 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
-<circle cx='272.12' cy='375.68' r='3.02' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
-<polygon points='290.88,369.95 294.95,376.99 286.81,376.99 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
-<circle cx='365.90' cy='376.01' r='3.02' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
-<polygon points='384.65,335.84 388.72,342.89 380.58,342.89 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
-<rect x='37.69' y='22.77' width='393.85' height='451.45' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMzcuNjl8NDMxLjU0fDIyLjc3fDQ2OS45Ng==)'>
+<rect x='37.69' y='22.77' width='393.85' height='447.19' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='37.69' y1='366.15' x2='431.54' y2='366.15' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='84.58' y1='324.78' x2='84.58' y2='308.14' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
+<line x1='103.33' y1='284.06' x2='103.33' y2='43.09' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
+<line x1='178.35' y1='373.89' x2='178.35' y2='366.64' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
+<line x1='197.10' y1='449.63' x2='197.10' y2='344.62' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
+<line x1='272.12' y1='375.21' x2='272.12' y2='369.51' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
+<line x1='290.88' y1='412.53' x2='290.88' y2='330.13' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
+<line x1='365.90' y1='374.77' x2='365.90' y2='370.58' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
+<line x1='384.65' y1='367.88' x2='384.65' y2='307.22' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
+<circle cx='84.58' cy='316.46' r='3.02' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
+<polygon points='103.33,158.88 107.40,165.93 99.26,165.93 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
+<circle cx='178.35' cy='370.27' r='3.02' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
+<polygon points='197.10,392.43 201.17,399.48 193.03,399.48 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
+<circle cx='272.12' cy='372.36' r='3.02' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
+<polygon points='290.88,366.63 294.95,373.68 286.81,373.68 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
+<circle cx='365.90' cy='372.68' r='3.02' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
+<polygon points='384.65,332.85 388.72,339.90 380.58,339.90 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
+<rect x='37.69' y='22.77' width='393.85' height='447.19' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<text x='32.76' y='372.44' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='32.76' y='217.78' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='14.69px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='32.76' y='63.13' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='14.69px' lengthAdjust='spacingAndGlyphs'>200</text>
-<polyline points='34.95,369.41 37.69,369.41 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='34.95,214.76 37.69,214.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='34.95,60.10 37.69,60.10 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='93.95,474.21 93.95,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='187.73,474.21 187.73,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='281.50,474.21 281.50,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='375.27,474.21 375.27,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='93.95' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
-<text x='187.73' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='281.50' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='375.27' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>8</text>
-<polyline points='164.28,487.74 398.72,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='281.50' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='52.83px' lengthAdjust='spacingAndGlyphs'>wt × (cyl = ...)</text>
-<text transform='translate(13.05,248.49) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
-<rect x='442.50' y='223.54' width='56.02' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='442.50' y='232.25' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='28.14px' lengthAdjust='spacingAndGlyphs'>group</text>
-<rect x='442.50' y='238.87' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='451.14' y1='254.43' x2='451.14' y2='240.60' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
-<circle cx='451.14' cy='247.51' r='3.02' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
-<rect x='442.50' y='256.15' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='451.14' y1='271.71' x2='451.14' y2='257.88' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
-<polygon points='451.14,260.09 455.21,267.14 447.07,267.14 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
-<text x='465.26' y='250.54' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='33.26px' lengthAdjust='spacingAndGlyphs'>lhs: mpg</text>
-<text x='465.26' y='267.82' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='25.93px' lengthAdjust='spacingAndGlyphs'>lhs: hp</text>
+<text x='32.76' y='369.17' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='32.76' y='215.98' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='14.69px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='32.76' y='62.78' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='14.69px' lengthAdjust='spacingAndGlyphs'>200</text>
+<polyline points='34.95,366.15 37.69,366.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,212.95 37.69,212.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,59.75 37.69,59.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='93.95,472.70 93.95,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='187.73,472.70 187.73,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='281.50,472.70 281.50,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='375.27,472.70 375.27,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='93.95' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
+<text x='187.73' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='281.50' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='375.27' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>8</text>
+<polyline points='150.22,485.61 412.78,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='281.50' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='52.83px' lengthAdjust='spacingAndGlyphs'>wt × (cyl = ...)</text>
+<text transform='translate(13.05,246.36) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
+<rect x='442.50' y='221.42' width='56.02' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='442.50' y='230.13' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='28.14px' lengthAdjust='spacingAndGlyphs'>group</text>
+<rect x='442.50' y='236.75' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='451.14' y1='252.30' x2='451.14' y2='238.48' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
+<circle cx='451.14' cy='245.39' r='3.02' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
+<rect x='442.50' y='254.03' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='451.14' y1='269.58' x2='451.14' y2='255.76' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
+<polygon points='451.14,257.97 455.21,265.02 447.07,265.02 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
+<text x='465.26' y='248.42' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='33.26px' lengthAdjust='spacingAndGlyphs'>lhs: mpg</text>
+<text x='465.26' y='265.70' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='25.93px' lengthAdjust='spacingAndGlyphs'>lhs: hp</text>
 <text x='37.69' y='14.55' style='font-size: 13.20px; font-family: "Liberation Sans";' textLength='119.28px' lengthAdjust='spacingAndGlyphs'>Effect on [mpg &amp; hp]</text>
 </g>
 </svg>

--- a/inst/tinytest/_tinysnapshot/ggcoefplot_multi_facet.svg
+++ b/inst/tinytest/_tinysnapshot/ggcoefplot_multi_facet.svg
@@ -21,45 +21,45 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.000000000000064' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMzcuNjl8MjMxLjg3fDM5LjQyfDQ3NC4yMQ=='>
-    <rect x='37.69' y='39.42' width='194.19' height='434.79' />
+  <clipPath id='cpMzcuNjl8MjMxLjg3fDM5LjQyfDQ2OS45Ng=='>
+    <rect x='37.69' y='39.42' width='194.19' height='430.54' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzcuNjl8MjMxLjg3fDM5LjQyfDQ3NC4yMQ==)'>
-<rect x='37.69' y='39.42' width='194.19' height='434.79' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='37.69' y1='373.28' x2='231.87' y2='373.28' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='65.43' y1='293.47' x2='65.43' y2='59.18' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
-<line x1='111.66' y1='454.45' x2='111.66' y2='352.35' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
-<line x1='157.90' y1='418.37' x2='157.90' y2='338.26' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
-<line x1='204.13' y1='374.96' x2='204.13' y2='315.98' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
-<polygon points='65.43,172.45 68.78,178.26 62.08,178.26 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
-<polygon points='111.66,399.53 115.01,405.33 108.31,405.33 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
-<polygon points='157.90,374.45 161.25,380.25 154.55,380.25 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
-<polygon points='204.13,341.60 207.48,347.41 200.78,347.41 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
-<rect x='37.69' y='39.42' width='194.19' height='434.79' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMzcuNjl8MjMxLjg3fDM5LjQyfDQ2OS45Ng==)'>
+<rect x='37.69' y='39.42' width='194.19' height='430.54' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='37.69' y1='370.01' x2='231.87' y2='370.01' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='65.43' y1='290.98' x2='65.43' y2='58.99' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
+<line x1='111.66' y1='450.39' x2='111.66' y2='349.29' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
+<line x1='157.90' y1='414.67' x2='157.90' y2='335.34' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
+<line x1='204.13' y1='371.68' x2='204.13' y2='313.28' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
+<polygon points='65.43,171.12 68.78,176.92 62.08,176.92 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
+<polygon points='111.66,395.97 115.01,401.77 108.31,401.77 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
+<polygon points='157.90,371.13 161.25,376.94 154.55,376.94 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
+<polygon points='204.13,338.61 207.48,344.42 200.78,344.42 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
+<rect x='37.69' y='39.42' width='194.19' height='430.54' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjM3LjM1fDQzMS41NHwzOS40Mnw0NzQuMjE='>
-    <rect x='237.35' y='39.42' width='194.19' height='434.79' />
+  <clipPath id='cpMjM3LjM1fDQzMS41NHwzOS40Mnw0NjkuOTY='>
+    <rect x='237.35' y='39.42' width='194.19' height='430.54' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjM3LjM1fDQzMS41NHwzOS40Mnw0NzQuMjE=)'>
-<rect x='237.35' y='39.42' width='194.19' height='434.79' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='237.35' y1='373.28' x2='431.54' y2='373.28' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='265.09' y1='333.06' x2='265.09' y2='316.88' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
-<line x1='311.33' y1='380.81' x2='311.33' y2='373.76' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
-<line x1='357.56' y1='382.08' x2='357.56' y2='376.55' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
-<line x1='403.80' y1='381.66' x2='403.80' y2='377.59' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
-<circle cx='265.09' cy='324.97' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
-<circle cx='311.33' cy='377.28' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
-<circle cx='357.56' cy='379.32' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
-<circle cx='403.80' cy='379.63' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
-<rect x='237.35' y='39.42' width='194.19' height='434.79' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMjM3LjM1fDQzMS41NHwzOS40Mnw0NjkuOTY=)'>
+<rect x='237.35' y='39.42' width='194.19' height='430.54' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='237.35' y1='370.01' x2='431.54' y2='370.01' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='265.09' y1='330.19' x2='265.09' y2='314.16' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
+<line x1='311.33' y1='377.47' x2='311.33' y2='370.49' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
+<line x1='357.56' y1='378.73' x2='357.56' y2='373.25' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
+<line x1='403.80' y1='378.32' x2='403.80' y2='374.28' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
+<circle cx='265.09' cy='322.18' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
+<circle cx='311.33' cy='373.98' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
+<circle cx='357.56' cy='375.99' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
+<circle cx='403.80' cy='376.30' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
+<rect x='237.35' y='39.42' width='194.19' height='430.54' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
 </g>
@@ -84,43 +84,43 @@
 <text x='334.45' y='34.12' text-anchor='middle' style='font-size: 8.80px;fill: #1A1A1A; font-family: "Liberation Sans";' textLength='17.12px' lengthAdjust='spacingAndGlyphs'>mpg</text>
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<polyline points='65.43,474.21 65.43,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='111.66,474.21 111.66,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='157.90,474.21 157.90,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='204.13,474.21 204.13,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='65.43' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
-<text x='111.66' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='157.90' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='204.13' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>8</text>
-<polyline points='100.10,487.74 215.69,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='157.90' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='52.83px' lengthAdjust='spacingAndGlyphs'>wt × (cyl = ...)</text>
-<polyline points='265.09,474.21 265.09,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='311.33,474.21 311.33,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='357.56,474.21 357.56,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='403.80,474.21 403.80,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='265.09' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
-<text x='311.33' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='357.56' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='403.80' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>8</text>
-<polyline points='299.77,487.74 415.36,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='357.56' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='52.83px' lengthAdjust='spacingAndGlyphs'>wt × (cyl = ...)</text>
-<text x='32.76' y='376.30' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='32.76' y='227.35' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='14.69px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='32.76' y='78.41' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='14.69px' lengthAdjust='spacingAndGlyphs'>200</text>
-<polyline points='34.95,373.28 37.69,373.28 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='34.95,224.33 37.69,224.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='34.95,75.38 37.69,75.38 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text transform='translate(13.05,256.81) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
-<rect x='442.50' y='231.87' width='56.02' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='442.50' y='240.58' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='28.14px' lengthAdjust='spacingAndGlyphs'>group</text>
-<rect x='442.50' y='247.20' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='451.14' y1='262.75' x2='451.14' y2='248.93' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
-<circle cx='451.14' cy='255.84' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
-<rect x='442.50' y='264.48' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='451.14' y1='280.03' x2='451.14' y2='266.21' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
-<polygon points='451.14,269.25 454.49,275.05 447.79,275.05 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
-<text x='465.26' y='258.87' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='33.26px' lengthAdjust='spacingAndGlyphs'>lhs: mpg</text>
-<text x='465.26' y='276.15' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='25.93px' lengthAdjust='spacingAndGlyphs'>lhs: hp</text>
+<polyline points='65.43,472.70 65.43,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='111.66,472.70 111.66,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='157.90,472.70 157.90,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='204.13,472.70 204.13,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='65.43' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
+<text x='111.66' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='157.90' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='204.13' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>8</text>
+<polyline points='93.17,485.61 222.63,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='157.90' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='52.83px' lengthAdjust='spacingAndGlyphs'>wt × (cyl = ...)</text>
+<polyline points='265.09,472.70 265.09,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='311.33,472.70 311.33,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='357.56,472.70 357.56,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='403.80,472.70 403.80,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='265.09' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
+<text x='311.33' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='357.56' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='403.80' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>8</text>
+<polyline points='292.83,485.61 422.29,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='357.56' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='52.83px' lengthAdjust='spacingAndGlyphs'>wt × (cyl = ...)</text>
+<text x='32.76' y='373.04' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='32.76' y='225.55' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='14.69px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='32.76' y='78.05' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='14.69px' lengthAdjust='spacingAndGlyphs'>200</text>
+<polyline points='34.95,370.01 37.69,370.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,222.52 37.69,222.52 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,75.03 37.69,75.03 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text transform='translate(13.05,254.69) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
+<rect x='442.50' y='229.74' width='56.02' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='442.50' y='238.45' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='28.14px' lengthAdjust='spacingAndGlyphs'>group</text>
+<rect x='442.50' y='245.07' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='451.14' y1='260.63' x2='451.14' y2='246.80' style='stroke-width: 1.07; stroke: #66C2A5; stroke-linecap: butt;' />
+<circle cx='451.14' cy='253.71' r='2.49' style='stroke-width: 0.71; stroke: none; fill: #66C2A5;' />
+<rect x='442.50' y='262.35' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='451.14' y1='277.91' x2='451.14' y2='264.08' style='stroke-width: 1.07; stroke: #FC8D62; stroke-linecap: butt;' />
+<polygon points='451.14,267.12 454.49,272.93 447.79,272.93 ' style='stroke-width: 0.71; stroke: none; fill: #FC8D62;' />
+<text x='465.26' y='256.74' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='33.26px' lengthAdjust='spacingAndGlyphs'>lhs: mpg</text>
+<text x='465.26' y='274.02' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='25.93px' lengthAdjust='spacingAndGlyphs'>lhs: hp</text>
 <text x='37.69' y='14.55' style='font-size: 13.20px; font-family: "Liberation Sans";' textLength='119.28px' lengthAdjust='spacingAndGlyphs'>Effect on [mpg &amp; hp]</text>
 </g>
 </svg>

--- a/inst/tinytest/_tinysnapshot/ggcoefplot_simple.svg
+++ b/inst/tinytest/_tinysnapshot/ggcoefplot_simple.svg
@@ -24,42 +24,42 @@
 <rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMzUuMjR8NDk4LjUyfDIyLjc3fDQ3NC4yMQ=='>
-    <rect x='35.24' y='22.77' width='463.28' height='451.45' />
+  <clipPath id='cpMzUuMjR8NDk4LjUyfDIyLjc3fDQ2OS45Ng=='>
+    <rect x='35.24' y='22.77' width='463.28' height='447.19' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzUuMjR8NDk4LjUyfDIyLjc3fDQ3NC4yMQ==)'>
-<rect x='35.24' y='22.77' width='463.28' height='451.45' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='101.42' y1='382.93' x2='101.42' y2='332.89' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='211.73' y1='453.69' x2='211.73' y2='336.91' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='322.03' y1='332.92' x2='322.03' y2='194.12' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='432.34' y1='259.08' x2='432.34' y2='43.29' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='101.42' cy='357.91' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='211.73' cy='395.30' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='322.03' cy='263.52' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='432.34' cy='151.18' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
-<rect x='35.24' y='22.77' width='463.28' height='451.45' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMzUuMjR8NDk4LjUyfDIyLjc3fDQ2OS45Ng==)'>
+<rect x='35.24' y='22.77' width='463.28' height='447.19' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='101.42' y1='379.54' x2='101.42' y2='329.97' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='211.73' y1='449.63' x2='211.73' y2='333.96' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='322.03' y1='330.00' x2='322.03' y2='192.51' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='432.34' y1='256.85' x2='432.34' y2='43.09' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='101.42' cy='354.75' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='211.73' cy='391.79' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='322.03' cy='261.25' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='432.34' cy='149.97' r='3.02' style='stroke-width: 0.71; fill: #000000;' />
+<rect x='35.24' y='22.77' width='463.28' height='447.19' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<text x='30.31' y='401.96' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='30.31' y='304.93' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>1.5</text>
-<text x='30.31' y='207.90' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text x='30.31' y='110.88' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<polyline points='32.50,398.93 35.24,398.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='32.50,301.91 35.24,301.91 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='32.50,204.88 35.24,204.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='32.50,107.85 35.24,107.85 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='101.42,474.21 101.42,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='211.73,474.21 211.73,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='322.03,474.21 322.03,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='432.34,474.21 432.34,476.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='101.42' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
-<text x='211.73' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='45.00px' lengthAdjust='spacingAndGlyphs'>Petal.Width</text>
-<text x='322.03' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='37.65px' lengthAdjust='spacingAndGlyphs'>versicolor</text>
-<text x='432.34' y='485.20' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='32.27px' lengthAdjust='spacingAndGlyphs'>virginica</text>
-<polyline points='294.46,487.74 459.91,487.74 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='377.19' y='497.61' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='31.31px' lengthAdjust='spacingAndGlyphs'>Species</text>
-<text transform='translate(13.05,248.49) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
+<text x='30.31' y='398.42' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='30.31' y='302.30' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='30.31' y='206.19' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='30.31' y='110.07' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<polyline points='32.50,395.39 35.24,395.39 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,299.28 35.24,299.28 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,203.16 35.24,203.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,107.05 35.24,107.05 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='101.42,472.70 101.42,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='211.73,472.70 211.73,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='322.03,472.70 322.03,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='432.34,472.70 432.34,469.96 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='101.42' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='35.23px' lengthAdjust='spacingAndGlyphs'>Constant</text>
+<text x='211.73' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='45.00px' lengthAdjust='spacingAndGlyphs'>Petal.Width</text>
+<text x='322.03' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='37.65px' lengthAdjust='spacingAndGlyphs'>versicolor</text>
+<text x='432.34' y='480.95' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='32.27px' lengthAdjust='spacingAndGlyphs'>virginica</text>
+<polyline points='277.91,485.61 476.46,485.61 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='377.19' y='496.69' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='31.31px' lengthAdjust='spacingAndGlyphs'>Species</text>
+<text transform='translate(13.05,246.36) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='137.03px' lengthAdjust='spacingAndGlyphs'>Estimate and 95% Conf. Int.</text>
 <text x='35.24' y='14.55' style='font-size: 13.20px; font-family: "Liberation Sans";' textLength='129.57px' lengthAdjust='spacingAndGlyphs'>Effect on Petal.Length</text>
 </g>
 </svg>

--- a/inst/tinytest/_tinysnapshot/ggiplot_list.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_list.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.000000000000064' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.000000000000064' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMjcuOTB8NDMzLjQ5fDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_complex.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_complex.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8Mzc1LjI2fDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_complex_kitchen.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_complex_kitchen.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.000000000000064' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8MjAwLjMwfDU2LjA3fDI0NS4yMA=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_complex_kitchen_iid.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_complex_kitchen_iid.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.000000000000064' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8MjAwLjMwfDU2LjA3fDI0NS4yMA=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_complex_mci.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_complex_mci.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8Mzc1LjI2fDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_csw.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_csw.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8MzU2LjIwfDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_csw_facet.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_csw_facet.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.000000000000064' y='-0.00000000000011' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8MTkwLjc3fDM5LjQyfDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_facet.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_facet.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.000000000000064' y='-0.00000000000011' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8MjAwLjMwfDM5LjQyfDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_facet_ribbon.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_facet_ribbon.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.000000000000064' y='-0.00000000000011' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8MjAwLjMwfDM5LjQyfDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_lhs.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_lhs.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.000000000000064' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.000000000000064' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzUuMjR8NDMxLjU0fDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_lhs_csw.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_lhs_csw.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8MzE4LjA0fDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_lhs_csw_facet.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_lhs_csw_facet.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8MTcxLjY5fDU2LjA3fDI0NS4yMA=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_lhs_facet.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_lhs_facet.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.000000000000064' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.000000000000064' y='-0.00000000000011' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzUuMjR8MjMwLjY1fDM5LjQyfDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_lhs_facet_ribbon.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_lhs_facet_ribbon.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.000000000000064' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.000000000000064' y='-0.00000000000011' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzUuMjR8MjMwLjY1fDM5LjQyfDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_single.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_single.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8Mzc1LjI2fDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_single_kitchen.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_single_kitchen.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8Mzc1LjI2fDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_single_kitchen_ribbon.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_single_kitchen_ribbon.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8Mzc1LjI2fDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_single_ribbon.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_single_ribbon.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8Mzc1LjI2fDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_multi_single_unnamed.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_multi_single_unnamed.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.000000000000064' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.000000000000064' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8NDMzLjQ5fDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_simple.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_simple.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMjcuOTB8NDk4LjUyfDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_simple_errorbar.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_simple_errorbar.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMjcuOTB8NDk4LjUyfDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_simple_mci.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_simple_mci.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMjcuOTB8NDk4LjUyfDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_simple_mci_ribbon.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_simple_mci_ribbon.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMjcuOTB8NDk4LjUyfDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_simple_ribbon.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_simple_ribbon.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMjcuOTB8NDk4LjUyfDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_stagg_mci.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_stagg_mci.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8NDk4LjUyfDIyLjc3fDQ3My4xMg=='>

--- a/inst/tinytest/_tinysnapshot/ggiplot_stagg_mci_ribbon.svg
+++ b/inst/tinytest/_tinysnapshot/ggiplot_stagg_mci_ribbon.svg
@@ -21,7 +21,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw1MDQuMDB8MC4wMHw1MDQuMDA=)'>
-<rect x='0.00' y='-0.000000000000057' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<rect x='0.00' y='0.00' width='504.00' height='504.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzAuODN8NDM5Ljg5fDIyLjc3fDQ3My4xMg=='>


### PR DESCRIPTION
Hi Grant,

I'm the author of ggh4x and I am sunsetting the `ggh4x::guide_*()` family of functions.
Because ggfixest uses `ggh4x::guide_axis_nested()`, this may cause problems for ggfixest.
This PR replaces ggh4x's guides with legendry's guides, which is the successor of ggh4x's guides.
Unfortunately there is not a 1:1 translation from ggfixest's use case to an easy legendry guide, so it takes a little bit more wrangling to get the guide to display correctly.

Best wishes,
Teun