### PR TITLE
Adapts tests to new VCOV default from fixest >= 0.13

### DIFF
--- a/inst/tinytest/test_aggr_es.R
+++ b/inst/tinytest/test_aggr_es.R
@@ -8,7 +8,8 @@ data("base_did", package = "fixest")
 
 est = fixest::feols(
 	fml = y ~ x1 + i(period, treat, 5) | id + period,
-	data = base_did
+	data = base_did,
+	vcov = "cluster"
 )
 
 aggr_post = aggr_es(est)                             # default post

--- a/inst/tinytest/test_iplot_data.R
+++ b/inst/tinytest/test_iplot_data.R
@@ -8,13 +8,15 @@ data("base_did", package = "fixest")
 
 est = fixest::feols(
 	fml = y ~ x1 + i(period, treat, 5) | id + period,
-	data = base_did
+	data = base_did,
+	vcov = "cluster"
 )
 
 est_log = fixest::feols(
 	fml = log(y) ~ x1 + i(period, treat, 5) | id + period,
 	data = base_did,
-	subset = ~ y >= 0
+	subset = ~ y >= 0,
+	vcov = "cluster"
 )
 
 


### PR DESCRIPTION
Hi Grant,

I've adapted the tests so that they can pass for both fixest >= v0.13 and fixest < v0.13.
I've simply added explicitly `vcov = "cluster"`.

So hopefully now all the rev dep checks from CRAN can pass :-)

Best,
L